### PR TITLE
[FEAT]: ChatRoom API 개발

### DIFF
--- a/src/main/java/com/chatbar/domain/chatroom/domain/ChatRoom.java
+++ b/src/main/java/com/chatbar/domain/chatroom/domain/ChatRoom.java
@@ -15,7 +15,9 @@ import org.hibernate.annotations.Where;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.EnumSet;
+import java.util.List;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -37,6 +39,7 @@ public class ChatRoom extends BaseEntity {
     private String desc;
 
     @Nullable
+    @Lob
     private EnumSet<Category> categories = EnumSet.noneOf(Category.class);
 
     private LocalDateTime openTime;

--- a/src/main/java/com/chatbar/domain/chatroom/domain/ChatRoom.java
+++ b/src/main/java/com/chatbar/domain/chatroom/domain/ChatRoom.java
@@ -39,12 +39,8 @@ public class ChatRoom extends BaseEntity {
     @Nullable
     private EnumSet<Category> categories = EnumSet.noneOf(Category.class);
 
-    @Nullable
-    @DateTimeFormat(pattern = "yyyy-MM-dd kk:mm:ss")
     private LocalDateTime openTime;
 
-    @Nullable
-    @DateTimeFormat(pattern = "yyyy-MM-dd kk:mm:ss")
     private LocalDateTime closeTime;
 
     private int maxParticipant = 16;

--- a/src/main/java/com/chatbar/domain/chatroom/dto/CreateRoomReq.java
+++ b/src/main/java/com/chatbar/domain/chatroom/dto/CreateRoomReq.java
@@ -1,9 +1,11 @@
 package com.chatbar.domain.chatroom.dto;
 
 import com.chatbar.domain.common.Category;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
+import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDateTime;
 import java.util.EnumSet;
@@ -18,8 +20,10 @@ public class CreateRoomReq {
 
     private EnumSet<Category> categories;
 
+    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime openTime;
 
+    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime closeTime;
 
     private int maxParticipant;

--- a/src/main/java/com/chatbar/domain/chatroom/dto/CreateRoomReq.java
+++ b/src/main/java/com/chatbar/domain/chatroom/dto/CreateRoomReq.java
@@ -1,13 +1,13 @@
 package com.chatbar.domain.chatroom.dto;
 
 import com.chatbar.domain.common.Category;
-import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.EnumSet;
 
 @Data
@@ -18,7 +18,8 @@ public class CreateRoomReq {
 
     private String desc;
 
-    private EnumSet<Category> categories;
+    @Nullable
+    private String[] categories;
 
     @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime openTime;

--- a/src/main/java/com/chatbar/domain/chatroom/dto/RoomListRes.java
+++ b/src/main/java/com/chatbar/domain/chatroom/dto/RoomListRes.java
@@ -1,10 +1,13 @@
 package com.chatbar.domain.chatroom.dto;
 
+import com.chatbar.domain.common.Category;
 import com.chatbar.domain.user.domain.User;
+import jakarta.persistence.Lob;
 import lombok.Builder;
 import lombok.Data;
 
 import java.time.LocalDateTime;
+import java.util.EnumSet;
 
 @Data
 public class RoomListRes {
@@ -19,13 +22,17 @@ public class RoomListRes {
 
     private String time;
 
+    @Lob
+    private EnumSet<Category> categories;
+
 
     @Builder
-    public RoomListRes(Long id, String name, String hostName, int current, int max, LocalDateTime open, LocalDateTime close) {
+    public RoomListRes(Long id, String name, String hostName, int current, int max, LocalDateTime open, LocalDateTime close, EnumSet<Category> categories) {
         this.id = id;
         this.name = name;
         this.hostName = hostName;
         this.participant = current + " / " + max;
         this.time = open + " ~ " + close;
+        this.categories = categories;
     }
 }

--- a/src/main/java/com/chatbar/domain/chatroom/presentation/ChatRoomController.java
+++ b/src/main/java/com/chatbar/domain/chatroom/presentation/ChatRoomController.java
@@ -54,6 +54,7 @@ public class ChatRoomController {
         return chatRoomService.findChatRoom(userPrincipal);
     }
 
+    //방 검색
     @GetMapping("/{search}")
     public ResponseEntity<?> searchChatRoom(
             @CurrentUser UserPrincipal userPrincipal,

--- a/src/main/java/com/chatbar/domain/chatroom/presentation/ChatRoomController.java
+++ b/src/main/java/com/chatbar/domain/chatroom/presentation/ChatRoomController.java
@@ -6,6 +6,7 @@ import com.chatbar.domain.chatroom.dto.EnterRoomReq;
 import com.chatbar.domain.user.domain.User;
 import com.chatbar.global.config.security.token.CurrentUser;
 import com.chatbar.global.config.security.token.UserPrincipal;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.apache.coyote.Response;
@@ -24,7 +25,7 @@ public class ChatRoomController {
     public ResponseEntity<?> createChatRoom(
             @CurrentUser UserPrincipal userPrincipal,
             @Valid @RequestBody CreateRoomReq createRoomReq
-    ){
+    ) throws JsonProcessingException {
         return chatRoomService.createChatRoom(userPrincipal, createRoomReq);
     }
 

--- a/src/main/java/com/chatbar/domain/common/Category.java
+++ b/src/main/java/com/chatbar/domain/common/Category.java
@@ -1,5 +1,43 @@
 package com.chatbar.domain.common;
 
 public enum Category {
-    SPORT, DRAMA, MOVIE, STUDY, GAME
+    PHOTHOG("사진"),
+    VOLUNTEERING("봉사"),
+    COSMETIC("화장"),
+    OUTDOOR("아웃도어"),
+    HOME_DECO("홈데코"),
+    DANCE("댄스"),
+    HISTORY("역사"),
+    CAR("차"),
+    SPORT("스포츠"),
+    DRAMA("드라마"),
+    MOVIE("영화"),
+    STUDY("공부"),
+    GAME("게임"),
+    ART("예술"),
+    MUSIC("음악"),
+    BOOK("책"),
+    HEALTH("헬스"),
+    CODING("코딩"),
+    FOOD("음식"),
+    COOKING("요리"),
+    KPOP("케이팝"),
+    FASHION("패션"),
+    WORK("일"),
+    TRAVEL("여행"),
+    KIDS("키즈");
+
+    private String value;
+
+    Category(String value) {
+        this.value = value;
+    }
+
+    public String getKey() {
+        return name();
+    }
+
+    public String getValue() {
+        return value;
+    }
 }


### PR DESCRIPTION
## 작업 내용 👨🏻‍💻

- [x] 방 만들기 API - 카테고리, 오픈 시간, 마감 시간 추가 가능 
- [x] 방 조회, 검색에 카테고리 추가
- [x] 방 입장 API - 이미 입장한 경우 예외 처리 추가  

## To Reviewers 💬
- 채팅방의 속성 중 카테고리, 오픈.마감시간에서 예상치 못한 오류들을 많이 만났습니다. 아래 레퍼런스들은 제가 오류들을 해결할 때 참고했던 사이트이고, 결과는 코드를 확인해주시면 되겠습니다.


## Reference 🔬 
- ✅ @Lob
- https://pinokio0702.tistory.com/142
- https://stackoverflow.com/questions/75042081/hibernate-6-postgres-and-bytea
- ✅ LocalDateTime 직렬화
- https://perfectacle.github.io/2018/01/15/jackson-local-date-time-deserialize/
- https://jojoldu.tistory.com/361
- ✅ Enum 활용 
- https://jojoldu.tistory.com/122
