### PR TITLE
[FEAT]: 유저 강퇴, 얼리기 API 개발

### DIFF
--- a/src/main/java/com/chatbar/domain/chatroom/domain/UserChatRoom.java
+++ b/src/main/java/com/chatbar/domain/chatroom/domain/UserChatRoom.java
@@ -13,6 +13,10 @@ import lombok.NoArgsConstructor;
 @Entity
 public class UserChatRoom extends BaseEntity {
 
+    public enum Role{
+        HOST, GUEST
+    }
+
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
@@ -20,14 +24,24 @@ public class UserChatRoom extends BaseEntity {
     @JoinColumn(name = "user_id")
     private User user;
 
+    private Role userRole; // 방장 or 손님
+
+    private boolean isFrozen; //얼려진 상태인지 -> false면 말할 수 있음.
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "chatRoom_id")
     private ChatRoom chatRoom;
 
     @Builder
-    public UserChatRoom(Long id, User user, ChatRoom chatRoom) {
+    public UserChatRoom(Long id, User user, ChatRoom chatRoom, Role userRole, boolean isFrozen) {
         this.id = id;
         this.user = user;
         this.chatRoom = chatRoom;
+        this.userRole = userRole;
+        this.isFrozen = isFrozen;
+    }
+
+    public void updateIsFrozen(boolean isFrozen) {
+        this.isFrozen = isFrozen;
     }
 }

--- a/src/main/java/com/chatbar/domain/chatroom/presentation/ChatRoomController.java
+++ b/src/main/java/com/chatbar/domain/chatroom/presentation/ChatRoomController.java
@@ -47,6 +47,26 @@ public class ChatRoomController {
         return chatRoomService.exitChatRoom(userPrincipal, roomId);
     }
 
+    //방 강퇴
+    @DeleteMapping("")
+    public ResponseEntity<?> kickOutChatRoom(
+            @CurrentUser UserPrincipal userPrincipal,
+            @RequestParam("roomId") Long roomId,
+            @RequestParam("userId") Long userId
+    ) {
+        return chatRoomService.kickOutChatRoom(userPrincipal, roomId, userId);
+    }
+
+    //유저 얼리기
+    @PatchMapping("")
+    public ResponseEntity<?> frozenUser(
+            @CurrentUser UserPrincipal userPrincipal,
+            @RequestParam("roomId") Long roomId,
+            @RequestParam("userId") Long userId
+    ) {
+        return chatRoomService.frozenUser(userPrincipal, roomId, userId);
+    }
+
     //방 조회
     @GetMapping
     public ResponseEntity<?> findChatRoom(

--- a/src/main/java/com/chatbar/domain/common/Category.java
+++ b/src/main/java/com/chatbar/domain/common/Category.java
@@ -1,7 +1,7 @@
 package com.chatbar.domain.common;
 
 public enum Category {
-    PHOTHOG("사진"),
+    PHOTO("사진"),
     VOLUNTEERING("봉사"),
     COSMETIC("화장"),
     OUTDOOR("아웃도어"),


### PR DESCRIPTION
## 작업 내용 👨🏻‍💻

- [x] 유저 강퇴 API 개발 
- [x] 유저 얼리기 API 개발 

## To Reviewers 💬
- UserChatRoom의 userRole이 enum값으로 저장이 안되는 문제 해결해야 합니다.
- 본인이 방장일 경우, 본인 강퇴가 허용됨. 딱히 문제 없을 것 같아서 예외 처리는 하지 않았습니다.


## Reference 🔬 
- 
