### PR TITLE
[FEAT]: 채팅방 참여기록 조회 API 생성

### DIFF
--- a/src/main/java/com/chatbar/domain/chatroom/domain/repository/UserChatRoomRepository.java
+++ b/src/main/java/com/chatbar/domain/chatroom/domain/repository/UserChatRoomRepository.java
@@ -20,4 +20,6 @@ public interface UserChatRoomRepository extends JpaRepository<UserChatRoom, Long
     List<UserChatRoom> findAllByChatRoomAndStatus(ChatRoom chatRoom, Status status);
 
     List<UserChatRoom> findAllByStatus(Status status);
+
+    List<UserChatRoom> findDistinctRoomIdByUserAndStatus(User user, Status status);
 }

--- a/src/main/java/com/chatbar/domain/chatroom/dto/RoomListRes.java
+++ b/src/main/java/com/chatbar/domain/chatroom/dto/RoomListRes.java
@@ -1,13 +1,6 @@
 package com.chatbar.domain.chatroom.dto;
 
-import com.chatbar.domain.common.Category;
-import com.chatbar.domain.common.CategorySetConverter;
 import com.chatbar.domain.common.Status;
-import com.chatbar.domain.user.domain.User;
-import jakarta.persistence.Convert;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.Lob;
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/chatbar/domain/chatroom/presentation/ChatRoomController.java
+++ b/src/main/java/com/chatbar/domain/chatroom/presentation/ChatRoomController.java
@@ -50,7 +50,7 @@ public class ChatRoomController {
     }
 
     //방 퇴장
-    @DeleteMapping("/{roomId}")
+    @PatchMapping("/{roomId}")
     public ResponseEntity<?> exitChatRoom(
             @CurrentUser UserPrincipal userPrincipal,
             @PathVariable(value = "roomId") Long roomId
@@ -127,5 +127,13 @@ public class ChatRoomController {
             @PathVariable(value = "roomId") Long roomId
     ) {
         return chatRoomService.findUsersInChatRoom(userPrincipal, roomId);
+    }
+
+    //참여했던 채팅방 기록 조회
+    @GetMapping("/records")
+    public ResponseEntity<?> findChatRoomRecord(
+            @CurrentUser UserPrincipal userPrincipal
+    ) {
+        return chatRoomService.findChatRoomRecord(userPrincipal);
     }
 }


### PR DESCRIPTION
## 작업 내용 👨🏻‍💻

- 채팅방 참여기록 state가 DELETE인 것만 조회되게 해놨습니다.
- 방 재입장 가능하게 수정했습니다.
- 재입장 시 ACTIVE로 바뀌면서 입장해있는 동안은 채팅방 기록에서 조회가 안됩니다.
- 방 퇴장 API는 DELETE에서 PATCH로 바뀌었습니다.

## To Reviewers 💬
- 


## Reference 🔬 
- 
